### PR TITLE
Use Calico hosted install

### DIFF
--- a/gce/Makefile
+++ b/gce/Makefile
@@ -23,6 +23,11 @@ NODE_IMAGE:=calico/node:${CALICO_CONT_VER}
 CNI_VER:=v0.3.0
 POD_CIDR:=192.168.0.0/16
 
+# GCE Scopes for the master.  These grant permissions to the master 
+# to read / write various bits of GCE config (e.g routes).
+# For ease, just allow all scopes.
+MASTER_SCOPES:=https://www.googleapis.com/auth/cloud-platform
+
 IPAM_PLUGIN_URL:=https://github.com/projectcalico/calico-cni/releases/download/$(CALICO_CNI_VER)/calico-ipam
 CNI_PLUGIN_URL:=https://github.com/containernetworking/cni/releases/download/$(CNI_VER)/cni-$(CNI_VER).tgz
 # URL of pre-configured Grafana DB.  Currently, this is empty apart from
@@ -255,6 +260,7 @@ deploy-master:
 	  --image-project coreos-cloud \
 	  --image $(GCE_IMAGE_NAME) \
 	  --machine-type $(MASTER_INSTANCE_TYPE) \
+	  --scopes $(MASTER_SCOPES) \
 	  --local-ssd interface=scsi \
 	  --metadata-from-file user-data=build/master-config-template.yaml & \
 	  echo "Waiting for creation of master node to finish..."; \

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -13,27 +13,22 @@ PROM_INSTANCE_TYPE:=n1-standard-4
 RR_INSTANCE_TYPE:=n1-standard-4
 PREFIX:=kube-scale
 GETTER_IMAGE:=caseydavenport/scale-tester:latest
-K8S_VER:=v1.3.6
-CALICO_POLICY_VER:=v0.3.0
-CALICO_CNI_VER:=v1.4.0-rc3
-CALICO_VER:=v0.21.0
-NODE_IMAGE:=calico/node:${CALICO_VER}
+K8S_VER:=v1.4.5
+CALICO_POLICY_VER:=v0.5.0
+CALICO_POLICY_IMAGE:=calico/kube-policy-controller:${CALICO_POLICY_VER}
+CALICO_CNI_VER:=v1.5.1
+CALICO_CNI_IMAGE:=calico/cni:${CALICO_CNI_VER}
+CALICO_CONT_VER:=v0.23.0
+NODE_IMAGE:=calico/node:${CALICO_CONT_VER}
 CNI_VER:=v0.3.0
+POD_CIDR:=192.168.0.0/16
 
-# Whether to use the unpacked CNI plugin (rather than the one-file, packed
-# version).  "y" or "n".  Note: this URL is for an experimental, unreleased
-# version of the plugin.  The purpose of this flag is to test whether using
-# an unpacked version of the plugin improves scale.
-USE_UNPACKED_CNI_PLUGIN:=n
-UNPACKED_CNI_PLUGIN_URL:=https://storage.googleapis.com/calico-scale-testing-files/calico-cni-unpacked-a1c2749-libcalico-f0f9f33.tgz
-# URL of the standard (packed) version of the CNI plugin.
-PACKED_CNI_PLUGIN_URL:=https://github.com/projectcalico/calico-cni/releases/download/$(CALICO_CNI_VER)/calico
 IPAM_PLUGIN_URL:=https://github.com/projectcalico/calico-cni/releases/download/$(CALICO_CNI_VER)/calico-ipam
 CNI_PLUGIN_URL:=https://github.com/containernetworking/cni/releases/download/$(CNI_VER)/cni-$(CNI_VER).tgz
 # URL of pre-configured Grafana DB.  Currently, this is empty apart from
 # having Prometheus pre-configured as the default data source.
 GRAFANA_DB_URL:=https://storage.googleapis.com/calico-scale-testing-files/grafana.db
-CALICOCTL_URL:=https://github.com/projectcalico/calico-containers/releases/download/${CALICO_VER}/calicoctl
+CALICOCTL_URL:=https://github.com/projectcalico/calico-containers/releases/download/${CALICO_CONT_VER}/calicoctl
 
 -include local-settings.mk
 
@@ -179,7 +174,6 @@ build/$(GCE_BUCKET).created:
 # Get all the CNI plugins.
 build/calico/calico:
 	mkdir -p build/calico
-	wget $(PACKED_CNI_PLUGIN_URL) -O build/calico/calico
 	wget $(IPAM_PLUGIN_URL) -O build/calico/calico-ipam
 	wget $(CNI_PLUGIN_URL) -O build/cni_plugin.tgz
 	tar -xvzf build/cni_plugin.tgz -C build/calico/
@@ -187,7 +181,6 @@ build/calico/calico:
 
 build/calico-cni-unpacked.tgz:
 	rm -f build/calico-cni-unpacked.tgz;
-	wget $(UNPACKED_CNI_PLUGIN_URL) -O build/calico-cni-unpacked.tgz
 
 # Takes the bare calico executable and packages it in a tgz so that its
 # structure matches the unpacked plugin.
@@ -198,14 +191,6 @@ build/calico-cni-packed-url: build/calico-cni-packed.tgz build/$(GCE_BUCKET).cre
 	gsutil cp build/calico-cni-packed.tgz gs://$(GCE_BUCKET)/calico-cni-packed.tgz
 	gsutil acl ch -u AllUsers:R gs://$(GCE_BUCKET)/calico-cni-packed.tgz
 	echo "https://storage.googleapis.com/$(GCE_BUCKET)/calico-cni-packed.tgz" > build/calico-cni-packed-url
-
-ifeq ($(USE_UNPACKED_CNI_PLUGIN), y)
-build/calico-cni-url: Makefile local-settings.mk
-	echo "$(UNPACKED_CNI_PLUGIN_URL)" > build/calico-cni-url
-else
-build/calico-cni-url: build/calico-cni-packed-url Makefile local-settings.mk
-	cp build/calico-cni-packed-url build/calico-cni-url
-endif
 
 run-local-prom:
 	# Prometheus needs a config file, but a blank one will do
@@ -339,6 +324,9 @@ build/etcd-template.yaml: templates/etcd-template.yaml Makefile local-settings.m
 	cat "$<" | \
 	  sed "s~__K8S_VER__~$(K8S_VER)~g" | \
 	  sed "s~__CALICO_POLICY_VER__~$(CALICO_POLICY_VER)~g" | \
+	  sed "s~__CALICO_POLICY_IMAGE__~$(CALICO_POLICY_IMAGE)~g" | \
+	  sed "s~__CALICO_CNI_IMAGE__~$(CALICO_CNI_IMAGE)~g" | \
+	  sed "s~__POD_CIDR__~$(POD_CIDR)~g" | \
 	  sed "s~__CALICOCTL_URL__~$(CALICOCTL_URL)~g" | \
 	  sed "s~__ETCD_PEER_URLS__~$(ETCD_PEER_URLS)~g" | \
 	  sed "s~__ETCD_CLIENT_URLS__~$(ETCD_CLIENT_URLS)~g" | \
@@ -347,16 +335,19 @@ build/etcd-template.yaml: templates/etcd-template.yaml Makefile local-settings.m
 	  sed "s~__GCE_PROJECT__~$(GCE_PROJECT)~g" | \
 	  sed "s~__NODE_IMAGE__~$(NODE_IMAGE)~g" | \
 	  sed "s~__GETTER_IMAGE__~$(GETTER_IMAGE)~g" | \
-	  sed "s~__CNI_PLUGIN_URL__~$$(cat build/calico-cni-url)~g" | \
+	  sed "s~__CNI_PLUGIN_URL__~$(CNI_PLUGIN_URL)~g" | \
 	  sed "s~__GRAFANA_DB_URL__~$(GRAFANA_DB_URL)~g" | \
 	  sed "s~__GRAFANA_DASH_JSON_URL__~$$(cat build/grafana-json-url)~g" | \
 	  sed "s~__PROMETHEUS_CONFIG_URL__~$$(cat build/prom-conf-url)~g" > $@;
 
-build/%: templates/% Makefile local-settings.mk build/calico-cni-url build/grafana-json-url build/prom-conf-url
+build/%: templates/% Makefile local-settings.mk build/grafana-json-url build/prom-conf-url
 	mkdir -p "$(@D)"
 	cat "$<" | \
 	  sed "s~__K8S_VER__~$(K8S_VER)~g" | \
 	  sed "s~__CALICO_POLICY_VER__~$(CALICO_POLICY_VER)~g" | \
+	  sed "s~__CALICO_POLICY_IMAGE__~$(CALICO_POLICY_IMAGE)~g" | \
+	  sed "s~__CALICO_CNI_IMAGE__~$(CALICO_CNI_IMAGE)~g" | \
+	  sed "s~__POD_CIDR__~$(POD_CIDR)~g" | \
 	  sed "s~__CALICOCTL_URL__~$(CALICOCTL_URL)~g" | \
 	  sed "s~__ETCD_PEER_URLS__~$(ETCD_PEER_URLS)~g" | \
 	  sed "s~__ETCD_CLIENT_URLS__~$(ETCD_CLIENT_URLS)~g" | \
@@ -365,7 +356,7 @@ build/%: templates/% Makefile local-settings.mk build/calico-cni-url build/grafa
 	  sed "s~__GCE_PROJECT__~$(GCE_PROJECT)~g" | \
 	  sed "s~__NODE_IMAGE__~$(NODE_IMAGE)~g" | \
 	  sed "s~__GETTER_IMAGE__~$(GETTER_IMAGE)~g" | \
-	  sed "s~__CNI_PLUGIN_URL__~$$(cat build/calico-cni-url)~g" | \
+	  sed "s~__CNI_PLUGIN_URL__~$(CNI_PLUGIN_URL)~g" | \
 	  sed "s~__GRAFANA_DB_URL__~$(GRAFANA_DB_URL)~g" | \
 	  sed "s~__GRAFANA_DASH_JSON_URL__~$$(cat build/grafana-json-url)~g" | \
 	  sed "s~__PROMETHEUS_CONFIG_URL__~$$(cat build/prom-conf-url)~g" > $@;

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -6,6 +6,7 @@ NUM_PODS:=300
 GCE_REGION:=us-central1-f
 GCE_PROJECT:=unique-caldron-775
 GCE_IMAGE_NAME:=coreos-stable-1122-3-0-v20161021
+GCE_IMAGE_PROJECT:=coreos-cloud
 MASTER_INSTANCE_TYPE:=n1-standard-16
 NODE_INSTANCE_TYPE:=n1-highcpu-4
 ETCD_INSTANCE_TYPE:=n1-standard-16
@@ -20,8 +21,12 @@ CALICO_CNI_VER:=v1.5.1
 CALICO_CNI_IMAGE:=calico/cni:${CALICO_CNI_VER}
 CALICO_CONT_VER:=v0.23.0
 NODE_IMAGE:=calico/node:${CALICO_CONT_VER}
+CALICOCTL_IMAGE:=calico/ctl:${CALICO_CONT_VER}
 CNI_VER:=v0.3.0
 POD_CIDR:=192.168.0.0/16
+
+# Image used by kubelet as infrastructure container.
+POD_INFRA_IMAGE=gcr.io/google_containers/pause:0.8.0
 
 # GCE Scopes for the master.  These grant permissions to the master 
 # to read / write various bits of GCE config (e.g routes).
@@ -257,10 +262,11 @@ deploy-master:
 	-gcloud compute instances create \
 	  $(PREFIX)-master \
 	  --zone $(GCE_REGION) \
-	  --image-project coreos-cloud \
+	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image $(GCE_IMAGE_NAME) \
 	  --machine-type $(MASTER_INSTANCE_TYPE) \
 	  --scopes $(MASTER_SCOPES) \
+	  --can-ip-forward \
 	  --local-ssd interface=scsi \
 	  --metadata-from-file user-data=build/master-config-template.yaml & \
 	  echo "Waiting for creation of master node to finish..."; \
@@ -271,11 +277,12 @@ deploy-nodes:
 	gcloud compute instances create \
 	  $(NODE_NAMES) \
 	  --zone $(GCE_REGION) \
-	  --image-project coreos-cloud \
+	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image $(GCE_IMAGE_NAME) \
 	  --machine-type $(NODE_INSTANCE_TYPE) \
 	  --metadata-from-file user-data=build/node-config-template.yaml \
 	  --no-address \
+	  --can-ip-forward \
 	  --tags no-ip & \
 	  echo "Waiting for creation of this batch of worker nodes to finish..."; \
 		wait; \
@@ -332,6 +339,7 @@ build/etcd-template.yaml: templates/etcd-template.yaml Makefile local-settings.m
 	  sed "s~__CALICO_POLICY_VER__~$(CALICO_POLICY_VER)~g" | \
 	  sed "s~__CALICO_POLICY_IMAGE__~$(CALICO_POLICY_IMAGE)~g" | \
 	  sed "s~__CALICO_CNI_IMAGE__~$(CALICO_CNI_IMAGE)~g" | \
+	  sed "s~__POD_INFRA_IMAGE__~$(POD_INFRA_IMAGE)~g" | \
 	  sed "s~__POD_CIDR__~$(POD_CIDR)~g" | \
 	  sed "s~__CALICOCTL_URL__~$(CALICOCTL_URL)~g" | \
 	  sed "s~__ETCD_PEER_URLS__~$(ETCD_PEER_URLS)~g" | \
@@ -340,6 +348,7 @@ build/etcd-template.yaml: templates/etcd-template.yaml Makefile local-settings.m
 	  sed "s~__CLUSTER_PREFIX__~$(PREFIX)~g" | \
 	  sed "s~__GCE_PROJECT__~$(GCE_PROJECT)~g" | \
 	  sed "s~__NODE_IMAGE__~$(NODE_IMAGE)~g" | \
+	  sed "s~__CALICOCTL_IMAGE__~$(CALICOCTL_IMAGE)~g" | \
 	  sed "s~__GETTER_IMAGE__~$(GETTER_IMAGE)~g" | \
 	  sed "s~__CNI_PLUGIN_URL__~$(CNI_PLUGIN_URL)~g" | \
 	  sed "s~__GRAFANA_DB_URL__~$(GRAFANA_DB_URL)~g" | \
@@ -353,6 +362,7 @@ build/%: templates/% Makefile local-settings.mk build/grafana-json-url build/pro
 	  sed "s~__CALICO_POLICY_VER__~$(CALICO_POLICY_VER)~g" | \
 	  sed "s~__CALICO_POLICY_IMAGE__~$(CALICO_POLICY_IMAGE)~g" | \
 	  sed "s~__CALICO_CNI_IMAGE__~$(CALICO_CNI_IMAGE)~g" | \
+	  sed "s~__POD_INFRA_IMAGE__~$(POD_INFRA_IMAGE)~g" | \
 	  sed "s~__POD_CIDR__~$(POD_CIDR)~g" | \
 	  sed "s~__CALICOCTL_URL__~$(CALICOCTL_URL)~g" | \
 	  sed "s~__ETCD_PEER_URLS__~$(ETCD_PEER_URLS)~g" | \
@@ -361,6 +371,7 @@ build/%: templates/% Makefile local-settings.mk build/grafana-json-url build/pro
 	  sed "s~__CLUSTER_PREFIX__~$(PREFIX)~g" | \
 	  sed "s~__GCE_PROJECT__~$(GCE_PROJECT)~g" | \
 	  sed "s~__NODE_IMAGE__~$(NODE_IMAGE)~g" | \
+	  sed "s~__CALICOCTL_IMAGE__~$(CALICOCTL_IMAGE)~g" | \
 	  sed "s~__GETTER_IMAGE__~$(GETTER_IMAGE)~g" | \
 	  sed "s~__CNI_PLUGIN_URL__~$(CNI_PLUGIN_URL)~g" | \
 	  sed "s~__GRAFANA_DB_URL__~$(GRAFANA_DB_URL)~g" | \
@@ -390,9 +401,16 @@ deploy-etcd: $(ETCD_CONFIG_FILENAMES)
 	wait; \
 	echo "etcd nodes started."
 
+clean: gce-cleanup
+	rm -rf build/*
+
 gce-cleanup:
+	# Clean up any instances.
 	gcloud compute instances list --zones $(GCE_REGION) -r '$(PREFIX).*' | \
 	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute instances delete --zone $(GCE_REGION)
+	# Clean up any routes created by the cluster.
+	gcloud compute routes list -r '$(PREFIX).*' | \
+	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute routes delete 
 
 gce-forward-ports:
 	@-pkill -f '8080:localhost:8080'

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -23,7 +23,7 @@ CALICO_CONT_VER:=v0.23.0
 NODE_IMAGE:=calico/node:${CALICO_CONT_VER}
 CALICOCTL_IMAGE:=calico/ctl:${CALICO_CONT_VER}
 CNI_VER:=v0.3.0
-POD_CIDR:=192.168.0.0/16
+POD_CIDR:=10.244.0.0/16
 
 # Image used by kubelet as infrastructure container.
 POD_INFRA_IMAGE=gcr.io/google_containers/pause:0.8.0

--- a/gce/README.md
+++ b/gce/README.md
@@ -21,6 +21,7 @@ These instructions have been tested on Ubuntu 14.04.  They are likely to work wi
   * `make gce-create`, this runs several gcloud commands to start the Kubernetes cluster; then it uses ssh to forward various local ports to the cluster.
   * Configure Kubernetes for the start of the test:
     * Wait for the hosts to check in with Kubernetes: `watch kubectl get nodes`.  You should see an entry in state "Ready" for each compute host.
+    * Install Calico: `kubectl apply -f build/manifests/calico.yaml`
     * `make prepare-getter` will check that the policy is in place and create all the namespaces, RCs, nginx pods, etc for the test run.
   * Run the test:
     * Either:

--- a/gce/templates/manifests/calico.yaml
+++ b/gce/templates/manifests/calico.yaml
@@ -1,0 +1,329 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config 
+  namespace: kube-system
+data:
+  # Configure this with the location of your etcd cluster.
+  etcd_endpoints: "__ETCD_ENDPOINTS__"
+
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "etcd_endpoints": "__ETCD_ENDPOINTS__",
+        "etcd_key_file": "__ETCD_KEY_FILE__",
+        "etcd_cert_file": "__ETCD_CERT_FILE__",
+        "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+        "log_level": "info",
+        "ipam": {
+            "type": "calico-ipam"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+  # The default IP Pool to be created for the cluster.
+  # Pod IP addresses will be assigned from this pool.
+  ippool.yaml: |
+      apiVersion: v1
+      kind: ipPool
+      metadata:
+        cidr: __POD_CIDR__ 
+      spec:
+        ipip:
+          enabled: true
+        nat-outgoing: true
+
+  # If you're using TLS enabled etcd uncomment the following.
+  # You must also populate the Secret below with these files.
+  etcd_ca: ""   # "/calico-secrets/etcd-ca"
+  etcd_cert: "" # "/calico-secrets/etcd-cert"
+  etcd_key: ""  # "/calico-secrets/etcd-key"
+
+---
+
+# The following contains k8s Secrets for use with a TLS enabled etcd cluster.
+# For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: calico-etcd-secrets
+  namespace: kube-system
+data:
+  # Populate the following files with etcd TLS configuration if desired, but leave blank if
+  # not using TLS for etcd.
+  # This self-hosted install expects three files with the following names.  The values 
+  # should be base64 encoded strings of the entire contents of each file.
+  # etcd-key: null
+  # etcd-cert: null
+  # etcd-ca: null
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on 
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This 
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: __NODE_IMAGE__ 
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Choose the backend to use. 
+            - name: CALICO_NETWORKING_BACKEND 
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Don't configure a default pool.  This is done by the Job
+            # below.
+            - name: NO_DEFAULT_POOLS
+              value: "true"
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /calico-secrets
+              name: etcd-certs
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: __CALICO_CNI_IMAGE__ 
+          imagePullPolicy: Always
+          command: ["/install-cni.sh"]
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Mount in the etcd TLS secrets.
+        - name: etcd-certs
+          secret:
+            secretName: calico-etcd-secrets
+
+---
+
+# This manifest deploys the Calico policy controller on Kubernetes.
+# See https://github.com/projectcalico/k8s-policy
+apiVersion: extensions/v1beta1
+kind: ReplicaSet 
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    scheduler.alpha.kubernetes.io/tolerations: |
+      [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+       {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+
+spec:
+  # The policy controller can only have a single active instance.
+  replicas: 1
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy
+    spec:
+      # The policy controller must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          image: __CALICO_POLICY_IMAGE__ 
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Since we're running in the host namespace and might not have KubeDNS 
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"
+          volumeMounts:
+            # Mount in the etcd TLS secrets.
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      volumes:
+        # Mount in the etcd TLS secrets.
+        - name: etcd-certs
+          secret:
+            secretName: calico-etcd-secrets
+
+---
+
+## This manifest deploys a Job which performs one time
+# configuration of Calico
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-calico
+  namespace: kube-system
+  labels:
+    k8s-app: calico
+spec:
+  template:
+    metadata:
+      name: configure-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      restartPolicy: OnFailure
+      containers:
+        # Writes basic configuration to datastore.
+        - name: configure-calico
+          image: __CALICOCTL_IMAGE__ 
+          args:
+          - apply
+          - -f
+          - /etc/config/calico/ippool.yaml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          env:
+            # The location of the etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+      volumes:
+       - name: config-volume
+         configMap:
+           name: calico-config
+           items:
+            - key: ippool.yaml
+              path: calico/ippool.yaml

--- a/gce/templates/manifests/canal-etcdless.yaml
+++ b/gce/templates/manifests/canal-etcdless.yaml
@@ -1,0 +1,178 @@
+# This ConfigMap can be used to configure a self-hosted Canal installation.
+# See `canal.yaml` for an example of a Canal deployment which uses
+# the config in this ConfigMap.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: canal-config 
+  namespace: kube-system
+data:
+  # The interface used by canal for host <-> host communication.
+  # If left blank, then the interface is chosing using the node's
+  # default route.
+  canal_iface: ""
+
+  # Whether or not to masquerade traffic to destinations not within
+  # the pod network.
+  masquerade: "true"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+  # Flannel network configuration.
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on 
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: canal
+  namespace: kube-system
+  labels:
+    k8s-app: canal
+spec:
+  selector:
+    matchLabels:
+      k8s-app: canal
+  template:
+    metadata:
+      labels:
+        k8s-app: canal
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This 
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: calico/node:v1.0.0-beta 
+          imagePullPolicy: Always
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSYS 
+              value: "debug"
+            # Don't enable BGP. 
+            - name: CALICO_NETWORKING_BACKEND 
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # No IP address needed. 
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: calico/cni:v1.5.0 
+          imagePullPolicy: Always
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+        # This container runs flannel using the kube-subnet-mgr backend
+        # for allocating subnets.
+        - name: kube-flannel
+          image: quay.io/coreos/flannel-git:v0.6.1-28-g5dde68d-amd64
+          command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+          securityContext:
+            privileged: true
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: FLANNELD_IFACE
+            valueFrom:
+              configMapKeyRef:
+                name: canal-config
+                key: canal_iface 
+          - name: FLANNELD_IP_MASQ
+            valueFrom:
+              configMapKeyRef:
+                name: canal-config
+                key: masquerade 
+          volumeMounts:
+          - name: run
+            mountPath: /run
+          - name: flannel-cfg
+            mountPath: /etc/kube-flannel/
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: run
+          hostPath:
+            path: /run
+        - name: flannel-cfg
+          configMap:
+            name: canal-config 

--- a/gce/templates/manifests/etcdless-calico.yaml
+++ b/gce/templates/manifests/etcdless-calico.yaml
@@ -1,0 +1,120 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config 
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on 
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This 
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: calico/node:v1.0.0-beta 
+          imagePullPolicy: Always
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSYS 
+              value: "debug"
+            # Don't enable BGP. 
+            - name: CALICO_NETWORKING_BACKEND 
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # No IP address needed. 
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: calico/cni:v1.5.0 
+          imagePullPolicy: Always
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -157,6 +157,7 @@ coreos:
         --cloud-provider=gce \
         --allocate-node-cidrs=true \
         --configure-cloud-routes=true \
+        --cluster-name=__CLUSTER_PREFIX__ \
         --cluster-cidr=__POD_CIDR__ \
         --logtostderr=true
         Restart=always
@@ -207,6 +208,7 @@ coreos:
         --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
+        --pod-infra-container-image=__POD_INFRA_IMAGE__ \ 
         --logtostderr=true
         Restart=always
         RestartSec=10

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -133,6 +133,7 @@ coreos:
         --allow-privileged=true \
         --etcd-servers=http://$private_ipv4:2379 \
         --runtime-config=extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true \
+        --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota \
         --insecure-bind-address=0.0.0.0 \
         --service-cluster-ip-range=10.100.0.0/24 \
         --logtostderr=true

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -152,6 +152,8 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
+        --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
+        --root-ca-file=/var/run/kubernetes/apiserver.crt \
         --logtostderr=true
         Restart=always
         RestartSec=10
@@ -184,11 +186,10 @@ coreos:
         [Service]
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__K8S_VER__/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
-        ExecStartPre=/usr/bin/mkdir -p /tmp/calico-cni-archive
-        ExecStartPre=/usr/bin/wget -O /tmp/calico-cni-archive/calico-cni.tgz __CNI_PLUGIN_URL__
-        ExecStartPre=/usr/bin/tar -C /opt -xzf /tmp/calico-cni-archive/calico-cni.tgz
+        ExecStartPre=/usr/bin/mkdir -p /tmp/cni-archive
+        ExecStartPre=/usr/bin/wget -O /tmp/cni-archive/cni.tgz __CNI_PLUGIN_URL__
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=/usr/bin/cp /opt/calico/loopback /opt/cni/bin/loopback
+        ExecStartPre=/usr/bin/tar -C /opt/cni/bin -xzf /tmp/cni-archive/cni.tgz
         ExecStart=/opt/bin/kubelet \
         --port=10250 \
         --address=0.0.0.0 \
@@ -201,7 +202,6 @@ coreos:
         --config=/etc/kubernetes/manifests \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
-        --hostname-override=127.0.0.1 \
         --logtostderr=true
         Restart=always
         RestartSec=10
@@ -256,9 +256,8 @@ coreos:
         After=docker.service
 
         [Service]
-        ExecStartPre=/usr/bin/test -f /opt/bin/calicoctl
-        ExecStartPre=-/usr/bin/ln -s /opt/bin/calicoctl /tmp/calicoctl
-        ExecStartPre=/usr/bin/wget -O /tmp/calico-cni.tgz __CNI_PLUGIN_URL__
+        ExecStartPre=/usr/bin/wget -O /tmp/calicoctl __CALICOCTL_URL__
+        ExecStartPre=/usr/bin/wget -O /tmp/cni.tgz __CNI_PLUGIN_URL__
         ExecStartPre=-/usr/bin/docker kill mynginx
         ExecStartPre=-/usr/bin/docker rm mynginx
         ExecStartPre=/usr/bin/docker pull nginx

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -154,6 +154,10 @@ coreos:
         --master=$private_ipv4:8080 \
         --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
         --root-ca-file=/var/run/kubernetes/apiserver.crt \
+        --cloud-provider=gce \
+        --allocate-node-cidrs=true \
+        --configure-cloud-routes=true \
+        --cluster-cidr=__POD_CIDR__ \
         --logtostderr=true
         Restart=always
         RestartSec=10
@@ -200,6 +204,7 @@ coreos:
         --cluster-domain=cluster.local \
         --api-servers=http://$private_ipv4:8080 \
         --config=/etc/kubernetes/manifests \
+        --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
         --logtostderr=true

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -154,9 +154,8 @@ coreos:
         --master=$private_ipv4:8080 \
         --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
         --root-ca-file=/var/run/kubernetes/apiserver.crt \
-        --cloud-provider=gce \
         --allocate-node-cidrs=true \
-        --configure-cloud-routes=true \
+        --configure-cloud-routes=false \
         --cluster-name=__CLUSTER_PREFIX__ \
         --cluster-cidr=__POD_CIDR__ \
         --logtostderr=true
@@ -205,7 +204,6 @@ coreos:
         --cluster-domain=cluster.local \
         --api-servers=http://$private_ipv4:8080 \
         --config=/etc/kubernetes/manifests \
-        --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
         --pod-infra-container-image=__POD_INFRA_IMAGE__ \ 

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -35,60 +35,6 @@ write_files:
     content: |
       127.0.0.1    localhost
 
-  # Network config file for the Calico CNI plugin.
-  - path: /etc/cni/net.d/10-calico.conf
-    owner: root
-    permissions: 0755
-    content: |
-      {
-          "name": "calico-k8s-network",
-          "type": "calico",
-          "etcd_endpoints": "__ETCD_ENDPOINTS__",
-          "log_level": "info",
-          "ipam": {
-              "type": "calico-ipam"
-          },
-          "policy": {
-              "type": "k8s",
-              "k8s_api_root": "http://127.0.0.1:8080/api/v1/"
-          }
-      }
-
-  # Manifest which starts the Calico policy controller on the master.
-  - path: /etc/kubernetes/manifests/calico-policy.yaml
-    owner: root
-    permissions: 0755
-    content: |
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: calico-policy-controller
-        namespace: calico-system
-      spec:
-        hostNetwork: true
-        containers:
-          # The Calico policy controller.
-          - name: k8s-policy-controller
-            image: calico/kube-policy-controller:latest
-            env:
-              # Modify ETCD_ENDPOINTS to match your etcd cluster.
-              - name: ETCD_ENDPOINTS
-                value: "__ETCD_ENDPOINTS__"
-              - name: K8S_API
-                value: "http://127.0.0.1:8080"
-              - name: LEADER_ELECTION
-                value: "true"
-          # Leader election container used by the policy agent.
-          - name: leader-elector
-            image: quay.io/calico/leader-elector:v0.1.0
-            imagePullPolicy: IfNotPresent
-            args:
-              - "--election=calico-policy-election"
-              - "--http=127.0.0.1:4040"
-            ports:
-              - containerPort: 4040
-                protocol: TCP
-
   # NetworkPolicy object used by the test to allow traffic from
   # the "getter" pods to the nginx service.
   - path: /home/core/nginx-policy.yaml
@@ -223,29 +169,6 @@ coreos:
         ExecStart=/opt/bin/kube-scheduler --master=$private_ipv4:8080
         Restart=always
         RestartSec=10
-    - name: calico-node.service
-      runtime: true
-      command: start
-      content: |
-        [Unit]
-        Description=calicoctl node
-        After=docker.service
-        Requires=docker.service
-
-        [Service]
-        User=root
-        Environment=ETCD_ENDPOINTS=__ETCD_ENDPOINTS__
-        PermissionsStartOnly=true
-        ExecStartPre=-/usr/bin/rm -f /opt/bin/calicoctl
-        ExecStartPre=/usr/bin/wget -P /opt/bin __CALICOCTL_URL__
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
-        ExecStartPre=/opt/bin/calicoctl pool add 192.168.0.0/16 --ipip --nat-outgoing
-        ExecStart=/opt/bin/calicoctl node --detach=false --node-image=__NODE_IMAGE__
-        Restart=always
-        RestartSec=10
-
-        [Install]
-        WantedBy=multi-user.target
 
     - name: kubelet.service
       runtime: true
@@ -256,7 +179,6 @@ coreos:
         Documentation=https://github.com/kubernetes/kubernetes
         After=docker.service
         After=etcd2.service
-        After=calico-node.service
         Requires=docker.service
 
         [Service]
@@ -266,8 +188,6 @@ coreos:
         ExecStartPre=/usr/bin/wget -O /tmp/calico-cni-archive/calico-cni.tgz __CNI_PLUGIN_URL__
         ExecStartPre=/usr/bin/tar -C /opt -xzf /tmp/calico-cni-archive/calico-cni.tgz
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=/usr/bin/cp /opt/calico/calico /opt/cni/bin/calico
-        ExecStartPre=/usr/bin/cp /opt/calico/calico-ipam /opt/cni/bin/calico-ipam
         ExecStartPre=/usr/bin/cp /opt/calico/loopback /opt/cni/bin/loopback
         ExecStart=/opt/bin/kubelet \
         --port=10250 \
@@ -349,7 +269,7 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    # Local Docker registry - nodes pull the calico/node image from here.
+    # Local Docker registry - nodes pull various images from here.
     - name: registry.service
       command: start
       content: |
@@ -365,6 +285,8 @@ coreos:
         ExecStartPre=-/usr/bin/docker pull registry:2
         ExecStartPre=-/usr/bin/docker pull __NODE_IMAGE__
         ExecStartPre=-/usr/bin/docker tag __NODE_IMAGE__ __CLUSTER_PREFIX__-master:5000/calico-node
+        ExecStartPre=-/usr/bin/docker pull __CALICO_CNI_IMAGE__
+        ExecStartPre=-/usr/bin/docker tag __CALICO_CNI_IMAGE__ __CLUSTER_PREFIX__-master:5000/calico-cni
         ExecStartPre=-/usr/bin/docker pull prom/node-exporter:latest
         ExecStartPre=-/usr/bin/docker tag prom/node-exporter:latest __CLUSTER_PREFIX__-master:5000/node-exporter
         ExecStartPre=-/usr/bin/docker pull __GETTER_IMAGE__
@@ -374,6 +296,7 @@ coreos:
         ExecStart=/usr/bin/docker run -p 5000:5000 --name registry registry:2
         ExecStartPost=/bin/sleep 5
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/calico-node
+        ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/calico-cni
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/node-exporter
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/scale-tester
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/routereflector

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -68,6 +68,7 @@ coreos:
         --cluster-dns=10.100.0.10 \
         --cluster-domain=cluster.local \
         --api-servers=http://__CLUSTER_PREFIX__-master:8080 \
+        --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
         --max-pods=110 \

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -11,25 +11,7 @@ write_files:
       # "  curl --upload-file /tmp/tmpRACajJ/diags-260516_123004.tar.gz https://transfer.sh/diags-260516_123004.tar.gz"
       FILE=`calicoctl diags | tail -1 | cut -f 5 -d " "`
       cat ${FILE}
-  # Network config file for the Calico CNI plugin.
-  - path: /etc/cni/net.d/10-calico.conf
-    owner: root
-    permissions: 0755
-    content: |
-      {
-          "name": "calico-k8s-network",
-          "type": "calico",
-          "etcd_authority": "127.0.0.1:2379",
-          "log_level": "debug",
-          "debug": true,
-          "ipam": {
-              "type": "calico-ipam"
-          },
-          "policy": {
-              "type": "k8s",
-              "k8s_api_root": "http://__CLUSTER_PREFIX__-master:8080/api/v1/"
-          }
-      }
+
   - path: /etc/resolv.conf
     owner: root
     permissions: 0755
@@ -54,29 +36,6 @@ coreos:
             ExecStartPre=/usr/bin/rm -rf /var/lib/docker
     - name: etcd2.service
       command: start
-    - name: calico-node.service
-      runtime: true
-      command: start
-      content: |
-        [Unit]
-        Description=calicoctl node
-        After=docker.service
-        Requires=docker.service
-
-        [Service]
-        User=root
-        Environment=ETCD_AUTHORITY=127.0.0.1:2379
-        PermissionsStartOnly=true
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin http://__CLUSTER_PREFIX__-master/calicoctl
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
-        ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/calico-node
-        ExecStartPre=/opt/bin/calicoctl config felix PrometheusMetricsEnabled true --force
-        ExecStart=/opt/bin/calicoctl node --node-image=__CLUSTER_PREFIX__-master:5000/calico-node --detach=false
-        Restart=always
-        RestartSec=10
-
-        [Install]
-        WantedBy=multi-user.target
 
     - name: kubelet.service
       runtime: true
@@ -87,7 +46,6 @@ coreos:
         Documentation=https://github.com/kubernetes/kubernetes
         After=docker.service
         After=etcd2.service
-        After=calico-node.service
         Requires=docker.service
 
         [Service]
@@ -96,8 +54,6 @@ coreos:
         ExecStartPre=/usr/bin/wget -N -P /tmp http://__CLUSTER_PREFIX__-master/calico-cni.tgz
         ExecStartPre=/usr/bin/tar -C /opt -xzf /tmp/calico-cni.tgz
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=/usr/bin/cp /opt/calico/calico /opt/cni/bin/calico
-        ExecStartPre=/usr/bin/cp /opt/calico/calico-ipam /opt/cni/bin/calico-ipam
         ExecStartPre=/usr/bin/cp /opt/calico/loopback /opt/cni/bin/loopback
         ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/scale-tester
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/scale-tester caseydavenport/scale-tester

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -51,12 +51,15 @@ coreos:
         [Service]
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__K8S_VER__/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
-        ExecStartPre=/usr/bin/wget -N -P /tmp http://__CLUSTER_PREFIX__-master/calico-cni.tgz
-        ExecStartPre=/usr/bin/tar -C /opt -xzf /tmp/calico-cni.tgz
+        ExecStartPre=/usr/bin/wget -N -P /tmp http://__CLUSTER_PREFIX__-master/cni.tgz
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=/usr/bin/cp /opt/calico/loopback /opt/cni/bin/loopback
+        ExecStartPre=/usr/bin/tar -C /opt/cni/bin -xzf /tmp/cni.tgz
         ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/scale-tester
+        ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/calico-cni
+        ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/calico-node
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/scale-tester caseydavenport/scale-tester
+        ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/calico-cni __CALICO_CNI_IMAGE__ 
+        ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/calico-node __NODE_IMAGE__ 
         ExecStartPre=/usr/bin/docker pull gcr.io/google_containers/pause:0.8.0
         ExecStart=/opt/bin/kubelet \
         --port=10250 \
@@ -67,7 +70,6 @@ coreos:
         --api-servers=http://__CLUSTER_PREFIX__-master:8080 \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
-        --hostname-override=$private_ipv4 \
         --max-pods=110 \
         --logtostderr=true
         Restart=always

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -60,7 +60,7 @@ coreos:
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/scale-tester caseydavenport/scale-tester
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/calico-cni __CALICO_CNI_IMAGE__ 
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/calico-node __NODE_IMAGE__ 
-        ExecStartPre=/usr/bin/docker pull gcr.io/google_containers/pause:0.8.0
+        ExecStartPre=/usr/bin/docker pull __POD_INFRA_IMAGE__ 
         ExecStart=/opt/bin/kubelet \
         --port=10250 \
         --address=0.0.0.0 \
@@ -71,6 +71,7 @@ coreos:
         --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
+        --pod-infra-container-image=__POD_INFRA_IMAGE__ \ 
         --max-pods=110 \
         --logtostderr=true
         Restart=always

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -68,7 +68,6 @@ coreos:
         --cluster-dns=10.100.0.10 \
         --cluster-domain=cluster.local \
         --api-servers=http://__CLUSTER_PREFIX__-master:8080 \
-        --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
         --pod-infra-container-image=__POD_INFRA_IMAGE__ \ 


### PR DESCRIPTION
This isn't quite working yet, but it's close.

This PR:
- Updates the scripts to use Calico hosted install.
- Updates the default versions of a number of components.

This PR doesn't yet:
- Adds support for GCE cloud-provider integration.
