### PR TITLE
Allow deployment of special high-perf tier of nodes

### DIFF
--- a/gce/Makefile
+++ b/gce/Makefile
@@ -1,6 +1,7 @@
 # Parameters for the cluster, don't edit these directly, put your changes in
 # local-settings.mk.
 CLUSTER_SIZE:=2
+NUM_HIGH_PERF_NODES:=1
 ETCD_CLUSTER_SIZE:=3
 NUM_PODS:=300
 GCE_REGION:=us-central1-f
@@ -12,6 +13,7 @@ NODE_INSTANCE_TYPE:=n1-highcpu-4
 ETCD_INSTANCE_TYPE:=n1-standard-16
 PROM_INSTANCE_TYPE:=n1-standard-4
 RR_INSTANCE_TYPE:=n1-standard-4
+HIGH_PERF_INSTANCE_TYPE:=n1-standard-8
 PREFIX:=kube-scale
 
 # Calico / Kubernetes versions.
@@ -59,10 +61,14 @@ NGINX_INSTANCES:=$(shell echo ${CLUSTER_SIZE}/10 + 1 | bc)
 # Generate node names.
 NODE_NUMBERS := $(shell seq -f '%03.0f' 1 $(CLUSTER_SIZE))
 NODE_NAMES := $(addprefix $(PREFIX)-,$(NODE_NUMBERS))
+
 ETCD_NODE_NUMBERS := $(shell seq -f '%02.0f' 1 $(ETCD_CLUSTER_SIZE))
 ETCD_NODE_SUFFIXES := $(addprefix etcd-,$(ETCD_NODE_NUMBERS))
 ETCD_NODE_NAMES := $(addprefix $(PREFIX)-,$(ETCD_NODE_SUFFIXES))
 ETCD_CONFIG_FILENAMES := $(addprefix build/etcd-,$(ETCD_NODE_NUMBERS))
+
+HIGH_PERF_NODE_NUMBERS := $(shell seq -f '%02.0f' 1 $(NUM_HIGH_PERF_NODES))
+HIGH_PERF_NODE_NAMES := $(addprefix $(PREFIX)-,highperf-$(NUM_HIGH_PERF_NODES))
 
 # Figure out what files need templating.
 INPUT_TEMPLATES := $(shell find templates/ -type f)
@@ -266,6 +272,7 @@ gce-create: kubectl calicoctl $(TEMPLATED_OUTPUT)
 	$(MAKE) --no-print-directory deploy-etcd
 	$(MAKE) --no-print-directory deploy-rr
 	$(MAKE) --no-print-directory deploy-nodes
+	$(MAKE) --no-print-directory deploy-high-perf-nodes
 	$(MAKE) --no-print-directory gce-config-ssh
 	$(MAKE) --no-print-directory gce-forward-ports
 	#$(MAKE) --no-print-directory apply-node-labels
@@ -281,7 +288,7 @@ deploy-master:
 	  --can-ip-forward \
 	  --local-ssd interface=scsi \
 	  --metadata-from-file user-data=build/master-config-template.yaml \
-	  --tags k8s-master,$(PREFIX) \
+	  --tags k8s-master,$(PREFIX) & \
 	  echo "Waiting for creation of master node to finish..."; \
 	  wait; \
 	  echo "master node started."
@@ -297,6 +304,22 @@ deploy-nodes:
 	  --no-address \
 	  --can-ip-forward \
 	  --tags no-ip,k8s-node,$(PREFIX) & \
+	  echo "Waiting for creation of this batch of worker nodes to finish..."; \
+		wait; \
+		echo "Batch of nodes created. Waiting 120s for cluster to settle down..."; \
+	  sleep 120;
+
+deploy-high-perf-nodes:
+	-gcloud compute instances create \
+	  $(HIGH_PERF_NODE_NAMES) \
+	  --zone $(GCE_REGION) \
+	  --image-project $(GCE_IMAGE_PROJECT) \
+	  --image $(GCE_IMAGE_NAME) \
+	  --machine-type $(HIGH_PERF_INSTANCE_TYPE) \
+	  --metadata-from-file user-data=build/node-config-template.yaml \
+	  --no-address \
+	  --can-ip-forward \
+	  --tags no-ip,k8s-node,high-perf,$(PREFIX) & \
 	  echo "Waiting for creation of this batch of worker nodes to finish..."; \
 		wait; \
 		echo "Batch of nodes created. Waiting 120s for cluster to settle down..."; \

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -18,7 +18,7 @@ PREFIX:=kube-scale
 
 # Calico / Kubernetes versions.
 K8S_VER:=v1.5.3
-CALICO_POLICY_VER:=v0.5.3
+CALICO_POLICY_VER:=v0.5.2
 CALICO_CNI_VER:=v1.6.0
 CALICO_CONT_VER:=v1.0.2
 CNI_VER:=v0.3.0
@@ -33,10 +33,11 @@ POD_CIDR:=10.244.0.0/16
 # Image used by kubelet as infrastructure container.
 POD_INFRA_IMAGE=gcr.io/google_containers/pause:0.8.0
 
-# GCE Scopes for the master.  These grant permissions to the master 
+# GCE Scopes for the master and nodes.  These grant permissions 
 # to read / write various bits of GCE config (e.g routes).
 # For ease, just allow all scopes.
 MASTER_SCOPES:=https://www.googleapis.com/auth/cloud-platform
+NODE_SCOPES:=https://www.googleapis.com/auth/cloud-platform
 
 # URL of pre-configured Grafana DB.  Currently, this is empty apart from
 # having Prometheus pre-configured as the default data source.
@@ -268,7 +269,6 @@ build/prom-conf-url: Makefile local-settings.mk build/prometheus.yml
 
 gce-create: kubectl calicoctl $(TEMPLATED_OUTPUT)
 	$(MAKE) --no-print-directory deploy-master
-	$(MAKE) --no-print-directory deploy-prom
 	$(MAKE) --no-print-directory deploy-etcd
 	$(MAKE) --no-print-directory deploy-rr
 	$(MAKE) --no-print-directory deploy-nodes
@@ -300,6 +300,7 @@ deploy-nodes:
 	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image $(GCE_IMAGE_NAME) \
 	  --machine-type $(NODE_INSTANCE_TYPE) \
+	  --scopes $(NODE_SCOPES) \
 	  --metadata-from-file user-data=build/node-config-template.yaml \
 	  --no-address \
 	  --can-ip-forward \
@@ -316,6 +317,7 @@ deploy-high-perf-nodes:
 	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image $(GCE_IMAGE_NAME) \
 	  --machine-type $(HIGH_PERF_INSTANCE_TYPE) \
+	  --scopes $(NODE_SCOPES) \
 	  --metadata-from-file user-data=build/node-config-template.yaml \
 	  --no-address \
 	  --can-ip-forward \
@@ -449,6 +451,10 @@ gce-cleanup:
 	# Clean up any routes created by the cluster.
 	gcloud compute routes list -r '$(PREFIX).*' | \
 	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute routes delete 
+	# Clean up any firewall-rules created by the cluster.
+	gcloud compute firewall-rules delete $(gcloud compute firewall-rules list | grep '$(PREFIX)' | awk '{print $1}')
+	# Clean up any disks created by the cluster.
+	gcloud compute disks delete $(gcloud compute disks list | grep '$(PREFIIX)' | awk '{print $1}')
 
 gce-forward-ports:
 	@-pkill -f '8080:localhost:8080'

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -17,6 +17,7 @@ write_files:
           }
         }
       }
+
   # Diags collection helper script:
   - path: /home/core/getcdiags.sh
     owner: root
@@ -324,15 +325,3 @@ coreos:
 
         [Install]
         WantedBy=multi-user.target
-
-    - name: node-exporter.service
-      command: start
-      content: |
-        [Unit]
-        Description=Prometheus node statistics exporter
-        After=docker.service
-        Requires=docker.service
-        [Service]
-        ExecStart=/usr/bin/docker run --rm --name node-exporter -p 9100:9100 --net="host" prom/node-exporter
-        Restart=always
-        RestartSec=10

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -145,6 +145,8 @@ coreos:
         --runtime-config=extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true \
         --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota \
         --insecure-bind-address=0.0.0.0 \
+        --cloud-provider=gce \
+        --cloud-config=/etc/gce.conf \
         --service-cluster-ip-range=10.100.0.0/24 \
         --logtostderr=true
         Restart=always
@@ -167,7 +169,7 @@ coreos:
         --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
         --root-ca-file=/var/run/kubernetes/apiserver.crt \
         --allocate-node-cidrs=true \
-        --configure-cloud-routes=false \
+        --configure-cloud-routes=true \
         --cloud-provider=gce \
         --cloud-config=/etc/gce.conf \
         --cluster-name=__CLUSTER_PREFIX__ \
@@ -312,7 +314,7 @@ coreos:
         ExecStartPre=-/usr/bin/docker pull prom/node-exporter:latest
         ExecStartPre=-/usr/bin/docker tag prom/node-exporter:latest __CLUSTER_PREFIX__-master:5000/node-exporter
         ExecStartPre=-/usr/bin/docker pull __GETTER_IMAGE__
-        ExecStartPre=-/usr/bin/docker tag __GETTER_IMAGE__ __CLUSTER_PREFIX__-master:5000/scale-tester
+        ExecStartPre=-/usr/bin/docker tag __GETTER_IMAGE__ __CLUSTER_PREFIX__-master:5000/getter
         ExecStartPre=-/usr/bin/docker pull calico/routereflector:latest
         ExecStartPre=-/usr/bin/docker tag calico/routereflector:latest __CLUSTER_PREFIX__-master:5000/routereflector
         ExecStart=/usr/bin/docker run -p 5000:5000 --name registry registry:2
@@ -320,7 +322,7 @@ coreos:
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/calico-node
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/calico-cni
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/node-exporter
-        ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/scale-tester
+        ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/getter
         ExecStartPost=/usr/bin/docker push __CLUSTER_PREFIX__-master:5000/routereflector
 
         [Install]

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -12,6 +12,15 @@ write_files:
       FILE=`calicoctl node diags | tail -1 | cut -f 7 -d " "`
       cat ${FILE}
 
+  # Cloud provider configuration.
+  - path: /etc/gce.conf
+    owner: root
+    permissions: 0755
+    content: |
+      [Global]
+      node-instance-prefix=__CLUSTER_PREFIX__
+      node-tags=__CLUSTER_PREFIX__
+
   # We need to do this because of a mismatch between what HOSTNAME reports,
   # and what Kubernetes expects.  We cut off the trailing bits of domain name
   # so it matches the GCE instance name.
@@ -113,6 +122,8 @@ coreos:
         --hostname-override=${HOSTNAME_OVERRIDE} \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
+        --cloud-provider=gce \
+        --cloud-config=/etc/gce.conf \
         --pod-infra-container-image=__POD_INFRA_IMAGE__ \
         --max-pods=110 \
         --logtostderr=true
@@ -135,19 +146,5 @@ coreos:
         --master=http://__CLUSTER_PREFIX__-master:8080 \
         --proxy-mode=iptables \
         --logtostderr=true
-        Restart=always
-        RestartSec=10
-
-    - name: node-exporter.service
-      command: start
-      content: |
-        [Unit]
-        Description=Prometheus node statistics exporter
-        After=docker.service
-        Requires=docker.service
-        [Service]
-        ExecStart=/usr/bin/docker run --rm --name node-exporter \
-                    -p 9100:9100 --net="host" __CLUSTER_PREFIX__-master:5000/node-exporter \
-                    -collectors.enabled=filefd,diskstats,loadavg,meminfo,stat,time,vmstat
         Restart=always
         RestartSec=10

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -105,10 +105,10 @@ coreos:
         ExecStartPre=/usr/bin/wget -N -P /opt/bin http://__CLUSTER_PREFIX__-master/calicoctl
         ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
         # prefetch images.
-        ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/scale-tester
+        ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/getter
         ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/calico-cni
         ExecStartPre=/usr/bin/docker pull __CLUSTER_PREFIX__-master:5000/calico-node
-        ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/scale-tester caseydavenport/scale-tester
+        ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/getter __GETTER_IMAGE__
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/calico-cni __CALICO_CNI_IMAGE__
         ExecStartPre=/usr/bin/docker tag __CLUSTER_PREFIX__-master:5000/calico-node __NODE_IMAGE__
         ExecStartPre=/usr/bin/docker pull __POD_INFRA_IMAGE__
@@ -120,10 +120,9 @@ coreos:
         --cluster-domain=cluster.local \
         --api-servers=http://__CLUSTER_PREFIX__-master:8080 \
         --hostname-override=${HOSTNAME_OVERRIDE} \
+        --cloud-provider=gce \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
-        --cloud-provider=gce \
-        --cloud-config=/etc/gce.conf \
         --pod-infra-container-image=__POD_INFRA_IMAGE__ \
         --max-pods=110 \
         --logtostderr=true


### PR DESCRIPTION
This PR:
- Allows the deployment of N "high-performance" 
- Removes the node-exporter from the node template.
- Enables GCE cloud-provider integration on the nodes for automatic labelling. 