### PR TITLE
Update for k8s 1.6

### DIFF
--- a/gce/Makefile
+++ b/gce/Makefile
@@ -513,7 +513,11 @@ gce-failed-pods:
 gce-wait-for-pod-creation:
 	bash -c 'while [ $$(kubectl get po | grep -P -c "1/1\s+Running\s+0") -ne $(NUM_PODS) ] ;  do date; echo "Not enough nodes created - waiting"; kubectl describe rc |grep "Pods Status"; sleep 1;done'
 
-gce-label-nodes:
-	kubectl label nodes $(HIGH_PERF_NODE_NAMES) cloud.google.com/gke-nodepool=infrastructure
-	kubectl label nodes $(NODE_NAMES) cloud.google.com/gke-nodepool=default-pool
+gce-label-infra-nodes:
+	kubectl label nodes --overwrite $(HIGH_PERF_NODE_NAMES) cloud.google.com/gke-nodepool=infrastructure
 
+gce-label-pool-nodes:
+	kubectl label nodes --overwrite $(NODE_NAMES) cloud.google.com/gke-nodepool=default-pool
+
+gce-clear-node-labels:
+	kubectl label nodes $(NODE_NAMES) cloud.google.com/gke-nodepool-

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -281,6 +281,8 @@ gce-create: kubectl calicoctl $(TEMPLATED_OUTPUT)
 	$(MAKE) --no-print-directory gce-config-ssh
 	$(MAKE) --no-print-directory gce-forward-ports
 	#$(MAKE) --no-print-directory apply-node-labels
+	$(MAKE) --no-print-directory gce-label-pool-nodes
+	$(MAKE) --no-print-directory gce-label-infra-nodes
 
 deploy-master:
 	-gcloud compute instances create \

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -6,7 +6,7 @@ ETCD_CLUSTER_SIZE:=3
 NUM_PODS:=300
 GCE_REGION:=us-central1-f
 GCE_PROJECT:=unique-caldron-775
-GCE_IMAGE_NAME:=coreos-stable-1122-3-0-v20161021
+GCE_IMAGE_FAMILY:=coreos-stable
 GCE_IMAGE_PROJECT:=coreos-cloud
 MASTER_INSTANCE_TYPE:=n1-standard-16
 NODE_INSTANCE_TYPE:=n1-highcpu-4
@@ -17,11 +17,11 @@ HIGH_PERF_INSTANCE_TYPE:=n1-standard-8
 PREFIX:=kube-scale
 
 # Calico / Kubernetes versions.
-K8S_VER:=v1.5.3
-CALICO_POLICY_VER:=v0.5.2
-CALICO_CNI_VER:=v1.6.0
-CALICO_CONT_VER:=v1.0.2
-CNI_VER:=v0.3.0
+K8S_VER:=v1.6.2
+CALICO_POLICY_VER:=v0.6.0
+CALICO_CNI_VER:=v1.8.0
+CALICO_CONT_VER:=v1.1.2-rc2
+CNI_VER:=v0.5.2
 
 # Images, based on above versions.
 GETTER_IMAGE:=calico/getter
@@ -287,7 +287,7 @@ deploy-master:
 	  $(PREFIX)-master \
 	  --zone $(GCE_REGION) \
 	  --image-project $(GCE_IMAGE_PROJECT) \
-	  --image $(GCE_IMAGE_NAME) \
+	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(MASTER_INSTANCE_TYPE) \
 	  --scopes $(MASTER_SCOPES) \
 	  --can-ip-forward \
@@ -303,7 +303,7 @@ deploy-nodes:
 	  $(NODE_NAMES) \
 	  --zone $(GCE_REGION) \
 	  --image-project $(GCE_IMAGE_PROJECT) \
-	  --image $(GCE_IMAGE_NAME) \
+	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(NODE_INSTANCE_TYPE) \
 	  --scopes $(NODE_SCOPES) \
 	  --metadata-from-file user-data=build/node-config-template.yaml \
@@ -320,7 +320,7 @@ deploy-high-perf-nodes:
 	  $(HIGH_PERF_NODE_NAMES) \
 	  --zone $(GCE_REGION) \
 	  --image-project $(GCE_IMAGE_PROJECT) \
-	  --image $(GCE_IMAGE_NAME) \
+	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(HIGH_PERF_INSTANCE_TYPE) \
 	  --scopes $(NODE_SCOPES) \
 	  --metadata-from-file user-data=build/node-config-template.yaml \
@@ -337,7 +337,7 @@ deploy-prom:
 	  $(PREFIX)-prom \
 	  --image-project coreos-cloud \
 	  --zone $(GCE_REGION) \
-	  --image $(GCE_IMAGE_NAME) \
+	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(PROM_INSTANCE_TYPE) \
 	  --metadata-from-file user-data=build/prom-config-template.yaml \
 	  --no-address \
@@ -351,7 +351,7 @@ deploy-rr:
 	  $(PREFIX)-rr1 $(PREFIX)-rr2  \
 	  --image-project coreos-cloud \
 	  --zone $(GCE_REGION) \
-	  --image $(GCE_IMAGE_NAME) \
+	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(RR_INSTANCE_TYPE) \
 	  --metadata-from-file user-data=build/rr-template.yaml \
 	  --no-address \
@@ -437,7 +437,7 @@ deploy-etcd: $(ETCD_CONFIG_FILENAMES)
 	    $(PREFIX)-etcd-$$ii \
 	    --zone $(GCE_REGION) \
 	    --image-project coreos-cloud \
-	    --image $(GCE_IMAGE_NAME) \
+	    --image-family $(GCE_IMAGE_FAMILY) \
 	    --machine-type $(ETCD_INSTANCE_TYPE) \
 	    --local-ssd interface=scsi \
 	    --no-address \
@@ -512,3 +512,8 @@ gce-failed-pods:
 
 gce-wait-for-pod-creation:
 	bash -c 'while [ $$(kubectl get po | grep -P -c "1/1\s+Running\s+0") -ne $(NUM_PODS) ] ;  do date; echo "Not enough nodes created - waiting"; kubectl describe rc |grep "Pods Status"; sleep 1;done'
+
+gce-label-nodes:
+	kubectl label nodes $(HIGH_PERF_NODE_NAMES) cloud.google.com/gke-nodepool=infrastructure
+	kubectl label nodes $(NODE_NAMES) cloud.google.com/gke-nodepool=default-pool
+

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -325,6 +325,7 @@ deploy-high-perf-nodes:
 	  --scopes $(NODE_SCOPES) \
 	  --metadata-from-file user-data=build/node-config-template.yaml \
 	  --no-address \
+	  --boot-disk-size=100GB \
 	  --can-ip-forward \
 	  --tags no-ip,k8s-node,high-perf,$(PREFIX) & \
 	  echo "Waiting for creation of this batch of worker nodes to finish..."; \

--- a/gce/templates/master-config-template.yaml
+++ b/gce/templates/master-config-template.yaml
@@ -148,6 +148,7 @@ coreos:
         --cloud-provider=gce \
         --cloud-config=/etc/gce.conf \
         --service-cluster-ip-range=10.100.0.0/24 \
+        --storage-backend=etcd2 \
         --logtostderr=true
         Restart=always
         RestartSec=10
@@ -220,8 +221,9 @@ coreos:
         --cluster-dns=10.100.0.10 \
         --cluster-domain=cluster.local \
         --api-servers=http://$private_ipv4:8080 \
-        --config=/etc/kubernetes/manifests \
-        --network-plugin-dir=/etc/cni/net.d \
+        --pod-manifest-path=/etc/kubernetes/manifests \
+        --cni-conf-dir=/etc/cni/net.d \
+        --cni-bin-dir=/opt/cni/bin \
         --network-plugin=cni \
         --pod-infra-container-image=__POD_INFRA_IMAGE__ \
         --logtostderr=true

--- a/gce/templates/node-config-template.yaml
+++ b/gce/templates/node-config-template.yaml
@@ -121,7 +121,8 @@ coreos:
         --api-servers=http://__CLUSTER_PREFIX__-master:8080 \
         --hostname-override=${HOSTNAME_OVERRIDE} \
         --cloud-provider=gce \
-        --network-plugin-dir=/etc/cni/net.d \
+        --cni-conf-dir=/etc/cni/net.d \
+        --cni-bin-dir=/opt/cni/bin \
         --network-plugin=__NETWORK_PLUGIN_MODE__ \
         --non-masquerade-cidr=__POD_CIDR__ \
         --pod-infra-container-image=__POD_INFRA_IMAGE__ \


### PR DESCRIPTION
- Updates for k8s 1.6
- Updates to match scale test operator 0.6.0

This PR contains the updates I found were required for scale testing of Calico 2.2 with k8s 1.6.2.