### PR TITLE
fixes and updates to Makefile 

### DIFF
--- a/gce/Makefile
+++ b/gce/Makefile
@@ -4,8 +4,8 @@ CLUSTER_SIZE:=2
 NUM_HIGH_PERF_NODES:=1
 ETCD_CLUSTER_SIZE:=3
 NUM_PODS:=300
-GCE_REGION:=us-central1-f
-REGION=$(shell echo '$(GCE_REGION)' | cut -f 1,2 -d '-')
+GCE_ZONE:=us-central1-f
+GCE_REGION=$(shell echo '$(GCE_ZONE)' | cut -f 1,2 -d '-')
 GCE_PROJECT:=unique-caldron-775
 GCE_IMAGE_FAMILY:=coreos-stable
 GCE_IMAGE_PROJECT:=coreos-cloud
@@ -288,7 +288,7 @@ gce-create: kubectl calicoctl $(TEMPLATED_OUTPUT)
 deploy-master:
 	-gcloud compute instances create \
 	  $(PREFIX)-master \
-	  --zone $(GCE_REGION) \
+	  --zone $(GCE_ZONE) \
 	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(MASTER_INSTANCE_TYPE) \
@@ -304,7 +304,7 @@ deploy-master:
 deploy-nodes:
 	-gcloud compute instances create \
 	  $(NODE_NAMES) \
-	  --zone $(GCE_REGION) \
+	  --zone $(GCE_ZONE) \
 	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(NODE_INSTANCE_TYPE) \
@@ -321,7 +321,7 @@ deploy-nodes:
 deploy-high-perf-nodes:
 	-gcloud compute instances create \
 	  $(HIGH_PERF_NODE_NAMES) \
-	  --zone $(GCE_REGION) \
+	  --zone $(GCE_ZONE) \
 	  --image-project $(GCE_IMAGE_PROJECT) \
 	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(HIGH_PERF_INSTANCE_TYPE) \
@@ -340,7 +340,7 @@ deploy-prom:
 	-gcloud compute instances create \
 	  $(PREFIX)-prom \
 	  --image-project coreos-cloud \
-	  --zone $(GCE_REGION) \
+	  --zone $(GCE_ZONE) \
 	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(PROM_INSTANCE_TYPE) \
 	  --metadata-from-file user-data=build/prom-config-template.yaml \
@@ -354,7 +354,7 @@ deploy-rr:
 	-gcloud compute instances create \
 	  $(PREFIX)-rr1 $(PREFIX)-rr2  \
 	  --image-project coreos-cloud \
-	  --zone $(GCE_REGION) \
+	  --zone $(GCE_ZONE) \
 	  --image-family $(GCE_IMAGE_FAMILY) \
 	  --machine-type $(RR_INSTANCE_TYPE) \
 	  --metadata-from-file user-data=build/rr-template.yaml \
@@ -365,7 +365,7 @@ deploy-rr:
 	  echo "route reflector node started."
 
 remove-prom:
-	gcloud compute instances delete --zone $(GCE_REGION) $(PREFIX)-prom
+	gcloud compute instances delete --zone $(GCE_ZONE) $(PREFIX)-prom
 
 # build/prometheus.yml needs its own templating to avoid a circular dependency.
 build/prometheus.yml: templates/prometheus.yml Makefile local-settings.mk
@@ -439,7 +439,7 @@ deploy-etcd: $(ETCD_CONFIG_FILENAMES)
 	  echo "Starting $(PREFIX)-etcd-$$ii"; \
 	  gcloud compute instances create \
 	    $(PREFIX)-etcd-$$ii \
-	    --zone $(GCE_REGION) \
+	    --zone $(GCE_ZONE) \
 	    --image-project coreos-cloud \
 	    --image-family $(GCE_IMAGE_FAMILY) \
 	    --machine-type $(ETCD_INSTANCE_TYPE) \
@@ -457,8 +457,8 @@ clean: gce-cleanup
 
 gce-cleanup:
 	# Clean up any instances.
-	gcloud compute instances list --zones $(GCE_REGION) -r '$(PREFIX).*' | \
-	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute instances delete --zone $(GCE_REGION)
+	gcloud compute instances list --zones $(GCE_ZONE) -r '$(PREFIX).*' | \
+	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute instances delete --zone $(GCE_ZONE)
 	# Clean up any routes created by the cluster.
 	gcloud compute routes list -r '$(PREFIX).*' | \
 	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute routes delete 
@@ -469,12 +469,12 @@ gce-cleanup:
 gce-cleanup-lbs:
 	# Clean up any load balancer instances.
 	gcloud compute forwarding-rules list | cut -f 1 -d ' ' | grep -v NAME \
-	  | xargs gcloud compute forwarding-rules delete --region='$(REGION)'
+	  | xargs gcloud compute forwarding-rules delete --region='$(GCE_REGION)'
 
 gce-forward-ports:
 	@-pkill -f '8080:localhost:8080'
-	bash -c 'until gcloud compute ssh --zone=$(GCE_REGION) core@$(PREFIX)-master -- -o LogLevel=quiet -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no date; do echo "Trying to forward ports"; sleep 1; done'
-	gcloud compute ssh --zone=$(GCE_REGION) core@$(PREFIX)-master -- -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+	bash -c 'until gcloud compute ssh --zone=$(GCE_ZONE) core@$(PREFIX)-master -- -o LogLevel=quiet -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no date; do echo "Trying to forward ports"; sleep 1; done'
+	gcloud compute ssh --zone=$(GCE_ZONE) core@$(PREFIX)-master -- -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
 	    -L 8080:localhost:8080 \
 	    -L 2379:localhost:2379 \
 	    -L 4194:localhost:4194 \

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -5,6 +5,7 @@ NUM_HIGH_PERF_NODES:=1
 ETCD_CLUSTER_SIZE:=3
 NUM_PODS:=300
 GCE_REGION:=us-central1-f
+REGION=$(shell echo '$(GCE_REGION)' | cut -f 1,2 -d '-')
 GCE_PROJECT:=unique-caldron-775
 GCE_IMAGE_FAMILY:=coreos-stable
 GCE_IMAGE_PROJECT:=coreos-cloud
@@ -159,7 +160,6 @@ get-results:
 # See http://stackoverflow.com/a/12110773/61318
 #make -j12 get-diags
 get-diags: describe-nodes describe-pods describe-services describe-rc describe-ep get-prom-data $(LOG_RETRIEVAL_TARGETS)
-get-diags2: describe-services describe-rc describe-ep get-prom-data $(LOG_RETRIEVAL_TARGETS)
 
 get-prom-data:
 	@mkdir -p timings
@@ -280,9 +280,11 @@ gce-create: kubectl calicoctl $(TEMPLATED_OUTPUT)
 	$(MAKE) --no-print-directory deploy-high-perf-nodes
 	$(MAKE) --no-print-directory gce-config-ssh
 	$(MAKE) --no-print-directory gce-forward-ports
-	#$(MAKE) --no-print-directory apply-node-labels
+	@echo "Waiting 20s to ensure a connection to the server is established..."
+	sleep 20
 	$(MAKE) --no-print-directory gce-label-pool-nodes
 	$(MAKE) --no-print-directory gce-label-infra-nodes
+	#$(MAKE) --no-print-directory apply-node-labels
 
 deploy-master:
 	-gcloud compute instances create \
@@ -462,9 +464,13 @@ gce-cleanup:
 	gcloud compute routes list -r '$(PREFIX).*' | \
 	  tail -n +2 | cut -f1 -d' ' | xargs gcloud compute routes delete 
 	# Clean up any firewall-rules created by the cluster.
-	gcloud compute firewall-rules delete $(gcloud compute firewall-rules list | grep '$(PREFIX)' | awk '{print $1}')
-	# Clean up any disks created by the cluster.
-	gcloud compute disks delete $(gcloud compute disks list | grep '$(PREFIIX)' | awk '{print $1}')
+	gcloud compute firewall-rules list | grep '$(PREFIX)' | cut -f 1 -d ' ' \
+	  | xargs gcloud compute firewall-rules delete
+
+gce-cleanup-lbs:
+	# Clean up any load balancer instances.
+	gcloud compute forwarding-rules list | cut -f 1 -d ' ' | grep -v NAME \
+	  | xargs gcloud compute forwarding-rules delete --region='$(REGION)'
 
 gce-forward-ports:
 	@-pkill -f '8080:localhost:8080'

--- a/gce/Makefile
+++ b/gce/Makefile
@@ -280,8 +280,7 @@ gce-create: kubectl calicoctl $(TEMPLATED_OUTPUT)
 	$(MAKE) --no-print-directory deploy-high-perf-nodes
 	$(MAKE) --no-print-directory gce-config-ssh
 	$(MAKE) --no-print-directory gce-forward-ports
-	@echo "Waiting 20s to ensure a connection to the server is established..."
-	sleep 20
+	bash -c 'while [ $$(curl 127.0.0.1:8080/version  2>&1 | grep -c refused) -ne "0" ] ;  do date; echo "Waiting till a connection to the API server is established...";  sleep 1;done'
 	$(MAKE) --no-print-directory gce-label-pool-nodes
 	$(MAKE) --no-print-directory gce-label-infra-nodes
 	#$(MAKE) --no-print-directory apply-node-labels


### PR DESCRIPTION
Updated gce-create to sleep a bit after forwarding ports to ensure a connection to the server is established before attempting kubectl commands.
Updating gce-cleanup to successfully delete firewall-rules and removed disk delete attempts since this is implicit when the nodes are deleted.
Added a target to clean-up load balancer instances.